### PR TITLE
avoid adding null comment in json reporter

### DIFF
--- a/src/main/java/app/getxray/xray/testng/listeners/XrayJsonReporter.java
+++ b/src/main/java/app/getxray/xray/testng/listeners/XrayJsonReporter.java
@@ -340,13 +340,14 @@ public class XrayJsonReporter implements IReporter, IExecutionListener, IInvoked
 
             // regular test; non data-driven
             ITestResult result =  results.get(0);           
+            String detailMessage = result.getThrowable().getMessage();
             String start = dateFormatter.format(result.getStartMillis());
             String finish = dateFormatter.format(result.getEndMillis());
             test.put("start", start);
             test.put("finish", finish);
             test.put("status", getTestStatus(result.getStatus()));
-            if (result.getStatus() == ITestResult.FAILURE)
-                test.put("comment", result.getThrowable().getMessage());
+            if (result.getStatus() == ITestResult.FAILURE && detailMessage != null)
+                test.put("comment", detailMessage);
 
             // process attachments
             processAttachments(result, test);


### PR DESCRIPTION
`org.testng.ITestResult#getThrowable` sometimes can have detailMessage=null, and this results in json-report having "comment":null and later a rejection from API when importing results via  '/api/v2/import/execution' (Xray Cloud).

TestNG test example that generates detailMessage=null:
```
@Test
@XrayTest(key = "EZ-76901")
public void testFailed() {
    assert false;
}
```

This PR adds an extra `detailMessage != null` check to fix this.